### PR TITLE
feat: personal collection mgmt

### DIFF
--- a/app/action/list.js
+++ b/app/action/list.js
@@ -1,5 +1,7 @@
+const config = require('../../config');
 const ConnectDB = require('../util/connectDB');
 const getResponse = require('../util/getResponse');
+const queryPersonal = require('../util/queryPersonal');
 const queryTags = require('../util/queryTags');
 const queryTorrents = require('../util/queryTorrents');
 
@@ -32,10 +34,12 @@ const list = async (req, res) => {
 		const rootGids = result.map(e => e.root_gid).filter(e => e);
 		const gidTags = await queryTags(conn, gids);
 		const gidTorrents = await queryTorrents(conn, rootGids);
+		const personal = config.features.personal && await queryPersonal(conn, gids);
 
 		result.forEach(e => {
 			e.tags = gidTags[e.gid] || [];
 			e.torrents = gidTorrents[e.root_gid] || [];
+			e.personal = personal[e.gid] || [];
 		});
 
 		return res.json(getResponse(result, 200, 'success', { total }));

--- a/app/action/personal.js
+++ b/app/action/personal.js
@@ -1,0 +1,28 @@
+const ConnectDB = require('../util/connectDB');
+const getResponse = require('../util/getResponse');
+
+/**
+ * 
+ * @param {import('express').Request} req 
+ * @param {import('express').Response} res 
+ * @returns 
+ */
+const personal = async (req, res) => {
+	const {gid, type, value} = Object.assign({}, req.body);
+
+	const conn = await new ConnectDB().connect();
+	try {
+		const cols = ['gid', type.toLowerCase()];
+		const paramStr = Array(cols.length).fill('?').join(',');
+		const result = await conn.query(
+			`INSERT INTO gallery_personal (${cols.join(',')}) VALUES (${paramStr})
+			ON DUPLICATE KEY UPDATE ${cols.map(c => `${c}=VALUES(${c})`).join(',')}`,
+			[gid, value]
+		);
+		return res.json(getResponse(result, 200, 'success', {}));
+	} finally {
+		conn.end();
+	}
+};
+
+module.exports = personal;

--- a/app/action/personal.js
+++ b/app/action/personal.js
@@ -8,16 +8,16 @@ const getResponse = require('../util/getResponse');
  * @returns 
  */
 const personal = async (req, res) => {
-	const {gid, type, value} = Object.assign({}, req.body);
+	const knownCols = ['gid', 'have', 'done', 'want', 'rating', 'note'];
+	const cols = knownCols.filter(c => req.body[c] != null);
 
 	const conn = await new ConnectDB().connect();
 	try {
-		const cols = ['gid', type.toLowerCase()];
 		const paramStr = Array(cols.length).fill('?').join(',');
 		const result = await conn.query(
 			`INSERT INTO gallery_personal (${cols.join(',')}) VALUES (${paramStr})
 			ON DUPLICATE KEY UPDATE ${cols.map(c => `${c}=VALUES(${c})`).join(',')}`,
-			[gid, value]
+			cols.map(c => req.body[c])
 		);
 		return res.json(getResponse(result, 200, 'success', {}));
 	} finally {

--- a/app/router/api/index.js
+++ b/app/router/api/index.js
@@ -8,6 +8,7 @@ const search = require('./search');
 const searchImage = require('./searchImage');
 const notFound = require('../../action/notFound');
 const comicInfo = require('./comicInfo');
+const personal = require('./personal');
 
 const router = Router();
 router.use('/gallery', gallery);
@@ -20,6 +21,7 @@ router.use('/uploader', uploader);
 router.use('/search', search);
 router.use('/searchimage', searchImage);
 router.use('/comicInfo', comicInfo);
+router.use('/personal', personal);
 router.use('/', notFound);
 
 module.exports = router;

--- a/app/router/api/personal.js
+++ b/app/router/api/personal.js
@@ -1,0 +1,8 @@
+const { Router } = require('express');
+const personal = require('../../action/personal');
+const catchError = require('../../util/catchError');
+
+const router = Router();
+router.use('/', catchError(personal));
+
+module.exports = router;

--- a/app/util/queryPersonal.js
+++ b/app/util/queryPersonal.js
@@ -1,0 +1,17 @@
+/**
+ * 
+ * @param {import("./connectDB")} conn 
+ * @param {number[]} gids 
+ */
+const queryPersonal = async (conn, gids) => {
+	const result = await conn.query(
+		'SELECT * FROM gallery_personal WHERE gid IN (?)', [gids]
+	);
+
+	return result.reduce((o, r) => {
+		o[r.gid] = r;
+		return o;
+	}, {});
+};
+
+module.exports = queryPersonal;

--- a/config.js
+++ b/config.js
@@ -9,4 +9,5 @@ module.exports = {
 	corsOrigin: '*',
 	webui: true,
 	webuiPath: 'frontend',
+	features: { personal: false },
 };

--- a/db/migrations/20240925004201_thumbnail-schema.sql
+++ b/db/migrations/20240925004201_thumbnail-schema.sql
@@ -1,17 +1,17 @@
 -- migrate:up
 
 CREATE TABLE IF NOT EXISTS `thumbnail` (
-  `id` int(11) NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `thumb` varchar(150) NOT NULL,
-  `ph0` int2 unsigned NOT NULL,
-  `ph1` int2 unsigned NOT NULL,
-  `ph2` int2 unsigned NOT NULL,
-  `ph3` int2 unsigned NOT NULL,
-  `bitcount` int1 NOT NULL,
+  `ph0` int2 unsigned,
+  `ph1` int2 unsigned,
+  `ph2` int2 unsigned,
+  `ph3` int2 unsigned,
+  `bitcount` int1,
   UNIQUE (`thumb`),
   INDEX bitcount_idx using btree (`bitcount`),
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 ALTER TABLE gallery ADD thumbnail_id int after thumb, ADD INDEX (thumbnail_id);
 
@@ -21,4 +21,4 @@ ALTER TABLE gallery ADD thumbnail_id int after thumb, ADD INDEX (thumbnail_id);
 ALTER TABLE gallery DROP thumbnail_id;
 
 -- letting table remain because it doesn't prevent rerunning migration
--- DROP TABLE thumbnail;
+DROP TABLE thumbnail;

--- a/db/migrations/20240929110332_gallery-personal-schema.sql
+++ b/db/migrations/20240929110332_gallery-personal-schema.sql
@@ -1,0 +1,14 @@
+-- migrate:up
+
+CREATE TABLE IF NOT EXISTS `gallery_personal` (
+    `gid` int(11) NOT NULL,
+    `have` bool, `done` bool, `want` bool,
+    `flags` bit(8),
+    `rating` varchar(4),
+    `note` text,
+    PRIMARY KEY (`gid`)
+) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
+
+
+-- migrate:down
+

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,10 @@ import React from 'react';
 import { hot } from 'react-hot-loader/root';
 import { BrowserRouter, Route } from 'react-router-dom';
 import Home from './components/Home';
+import config from 'config';
+import featureFlags from './util/featureFlags';
+
+featureFlags.initialize(config.features);
 
 const App = () => (
 	<BrowserRouter>

--- a/src/components/Gallery/Gallery.css
+++ b/src/components/Gallery/Gallery.css
@@ -77,6 +77,8 @@
 
 .tags {
 	padding-top: 10px;
+    flex-basis: 60%;
+    flex-grow: 1;
 }
 
 .tagLine {
@@ -102,6 +104,42 @@
 	padding: 2px 6px;
 	text-decoration: none;
 	margin-right: 5px;
+}
+
+.content {
+    display: flex;
+    justify-content: space-between;
+}
+
+.note {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    flex-basis: 15%;
+    flex-grow: 1;
+}
+.note a {
+	user-select: none;
+}
+.note div {
+	border: 1px dashed;
+	padding: 5px;
+	white-space: pre-wrap;
+}
+
+.personal {
+	margin: 20px auto;
+}
+.checkbox {
+	display: inline-block;
+	border: 1px solid #888;
+	border-radius: 3px;
+	padding: 2px 6px;
+	text-decoration: none;
+	margin-right: 5px;
+}
+.checkbox * {
+	vertical-align: middle;
 }
 
 .torrentLink {

--- a/src/components/Gallery/Gallery.js
+++ b/src/components/Gallery/Gallery.js
@@ -8,13 +8,25 @@ import Rating from '../Rating';
 import parseEntity from '../../util/parseEntity';
 import Modal from '../Modal/Modal';
 import Torrent from '../Torrent';
+import featureFlags from 'src/util/featureFlags';
 
 const Gallery = ({
 	thumb, category, uploader, posted, expunged, removed, replaced, filesize, filecount,
-	title, title_jpn, rating, tags = [], gid, token, torrents, onSearch = () => {}
+	title, title_jpn, rating, tags = [], gid, token, torrents, personal,
+	onSearch = () => {}, onPersonal = () => {}
 }) => {
 	const [visible, setVisible] = useState(false);
 	const toggleTorrentModal = () => setVisible(!visible);
+
+	const onHave = () => {
+		onPersonal(gid, 'Have', !personal.have)
+	};
+	const onDone = () => {
+		onPersonal(gid, 'Done', !personal.done)
+	};
+	const onWant = () => {
+		onPersonal(gid, 'Want', !personal.want)
+	};
 
 	const tagList = {};
 	tags.forEach(e => {
@@ -29,6 +41,31 @@ const Gallery = ({
 		? thumb
 		: `pandathumbs/${thumb.slice(0,2)}/${thumb.slice(2,4)}/${thumb}`
 	).replace(/_l\./, '_250.')
+
+	const renderPersonal = () => {
+		if (!featureFlags.isEnabled('personal') || !personal) {
+			return null;
+		}
+		return <div className={styles.personal}>
+			<div className={styles.metaSingleItem}>
+				<label className={styles.checkbox}>
+					<input type="checkbox" checked={personal.have} onChange={onHave}/>
+					<span>Have</span>
+				</label>
+				<label className={styles.checkbox}>
+					<input type="checkbox" checked={personal.done} onChange={onDone}/>
+					<span>Read</span>
+				</label>
+				<label className={styles.checkbox}>
+					<input type="checkbox" checked={personal.want} onChange={onWant}/>
+					<span>Want</span>
+				</label>
+			</div>
+			<div className={styles.metaSingleItem}>
+				{personal.have && <a href={`panda://${gid}`}>Open cbz</a>}
+			</div>
+		</div>;
+	};
 
 	return (
 		<div className={styles.container}>
@@ -136,6 +173,7 @@ const Gallery = ({
 						{rating}
 					</span>
 				</div>
+				{personal && renderPersonal()}
 			</div>
 			<div className={styles.main}>
 				<div className={styles.header}>

--- a/src/components/Gallery/Gallery.js
+++ b/src/components/Gallery/Gallery.js
@@ -10,22 +10,29 @@ import Modal from '../Modal/Modal';
 import Torrent from '../Torrent';
 import featureFlags from 'src/util/featureFlags';
 
+/**
+ * @param {import('@types').GalleryOptions} args
+ */
 const Gallery = ({
 	thumb, category, uploader, posted, expunged, removed, replaced, filesize, filecount,
 	title, title_jpn, rating, tags = [], gid, token, torrents, personal,
 	onSearch = () => {}, onPersonal = () => {}
 }) => {
 	const [visible, setVisible] = useState(false);
+	const [isEditNote, setEditNote] = useState(false);
+	const [myRating, setMyRating] = useState(personal?.rating);
 	const toggleTorrentModal = () => setVisible(!visible);
 
-	const onHave = () => {
-		onPersonal(gid, 'Have', !personal.have)
+	const onChangePersonal = (newPersonal) => {
+		if (newPersonal.rating) {
+			setMyRating(newPersonal.rating);
+		}
+		onPersonal({...personal, ...newPersonal});
 	};
-	const onDone = () => {
-		onPersonal(gid, 'Done', !personal.done)
-	};
-	const onWant = () => {
-		onPersonal(gid, 'Want', !personal.want)
+
+	const onNoteSave = () => {
+		onPersonal(personal);
+		setEditNote(false);
 	};
 
 	const tagList = {};
@@ -49,15 +56,15 @@ const Gallery = ({
 		return <div className={styles.personal}>
 			<div className={styles.metaSingleItem}>
 				<label className={styles.checkbox}>
-					<input type="checkbox" checked={personal.have} onChange={onHave}/>
+					<input type="checkbox" checked={personal.have} onChange={() => onChangePersonal({have: !personal.have})}/>
 					<span>Have</span>
 				</label>
 				<label className={styles.checkbox}>
-					<input type="checkbox" checked={personal.done} onChange={onDone}/>
+					<input type="checkbox" checked={personal.done} onChange={() => onChangePersonal({done: !personal.done})}/>
 					<span>Read</span>
 				</label>
 				<label className={styles.checkbox}>
-					<input type="checkbox" checked={personal.want} onChange={onWant}/>
+					<input type="checkbox" checked={personal.want} onChange={() => onChangePersonal({want: !personal.want})}/>
 					<span>Want</span>
 				</label>
 			</div>
@@ -173,6 +180,15 @@ const Gallery = ({
 						{rating}
 					</span>
 				</div>
+				{featureFlags.isEnabled('personal') &&
+					<div className={styles.metaItem}>
+						<span className={styles.metaLabel}>My Rating:</span>
+						<span className={styles.metaValue}>
+							<Rating value={myRating} onClick={i => onChangePersonal({rating: i})} />
+							{myRating}
+						</span>
+					</div>
+				}
 				{personal && renderPersonal()}
 			</div>
 			<div className={styles.main}>
@@ -184,25 +200,41 @@ const Gallery = ({
 						{parseEntity(title_jpn)}
 					</h3>
 				</div>
-				<div className={styles.tags}>
-					{Object.entries(tagList).map(([type, list]) => (
-						<div className={styles.tagLine} key={type}>
-							<div className={styles.tagType}>{type}:</div>
-							<div className={styles.tagList}>
-								{list.map(tag => (
-									<a
-										key={tag}
-										onClick={(event) => onSearch({
-											keyword: `${type === 'misc' ? '' : `${type}:`}${/\s/.test(tag) ? `"${tag}$"` : `${tag}$`}`
-										}, {
-											append: event.ctrlKey,
-										})}>
-										{tag}
-									</a>
-								))}
+				<div className={styles.content}>
+					<div className={styles.tags}>
+						{Object.entries(tagList).map(([type, list]) => (
+							<div className={styles.tagLine} key={type}>
+								<div className={styles.tagType}>{type}:</div>
+								<div className={styles.tagList}>
+									{list.map(tag => (
+										<a
+											key={tag}
+											onClick={(event) => onSearch({
+												keyword: `${type === 'misc' ? '' : `${type}:`}${/\s/.test(tag) ? `"${tag}$"` : `${tag}$`}`
+											}, {
+												append: event.ctrlKey,
+											})}>
+											{tag}
+										</a>
+									))}
+								</div>
 							</div>
+						))}
+					</div>
+					{featureFlags.isEnabled('personal') &&
+						<div className={styles.note}>
+							<a onClick={() => setEditNote(!isEditNote)}>{isEditNote ? 'Cancel' : 'Edit note'}</a>
+							{isEditNote
+								? <>
+									<textarea rows={5} cols={22}
+										onChange={(evt) => personal.note = evt.target.value}
+										value={personal.note} />
+									<a onClick={onNoteSave}>save</a>
+								</>
+								: personal.note && <div>{personal.note}</div>
+							}
 						</div>
-					))}
+					}
 				</div>
 			</div>
 			<Modal visible={visible} onClose={toggleTorrentModal}>

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -2,11 +2,11 @@ import React from 'react';
 import Gallery from '../Gallery';
 import styles from './List.css';
 
-const List = ({ list = [], loading = false, onSearch }) => (
+const List = ({ list = [], loading = false, onSearch, onPersonal }) => (
 	<div className={[styles.container, loading ? styles.loading : ''].join(' ').trim()}>
 		{list.map(e => (
 			<div className={styles.item} key={e.gid}>
-				<Gallery {...e} onSearch={onSearch} />
+				<Gallery {...e} onSearch={onSearch} onPersonal={onPersonal}/>
 			</div>
 		))}
 	</div>

--- a/src/components/Rating/Rating.js
+++ b/src/components/Rating/Rating.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import Star from './Star';
 
-const Rating = ({ value = 0 }) => {
+/**
+ * 
+ * @param {{value: number, onClick?: (i: number) => void}} args
+ * @returns 
+ */
+const Rating = ({ value = 0, onClick = undefined }) => {
 	let rating = +value + 1;
 	const starConfig = new Array(5).fill('').map(() => {
 		rating -= 1;
@@ -15,7 +20,7 @@ const Rating = ({ value = 0 }) => {
 	});
 
 	return starConfig.map((e, i) => (
-		<Star key={i} {...e} />
+		<Star key={i} onClick={() => onClick && onClick(i + 1)} {...e} />
 	));
 };
 

--- a/src/components/Rating/Star.js
+++ b/src/components/Rating/Star.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import styles from './Rating.css';
 
-const Star = ({ half = false, full = false }) => (
-	<span className={`${styles.star} ${half ? styles.half : full ? styles.full : ''}`.trim()} />
+/**
+ * 
+ * @param {{half?: boolean, full?: boolean, onClick?: () => void}} args
+ * @returns 
+ */
+const Star = ({ half = false, full = false, onClick = undefined }) => (
+	<span onClick={onClick} className={`${styles.star} ${half ? styles.half : full ? styles.full : ''}`.trim()} />
 );
 
 export default Star;

--- a/src/components/SearchBox/SearchBox.css
+++ b/src/components/SearchBox/SearchBox.css
@@ -81,11 +81,16 @@
 	vertical-align: middle;
 	text-align: left;
 	line-height: 25px;
+	font-family: sans-serif;
 }
 
 .advanceItem {
 	display: inline-block;
 	width: 50%;
+}
+
+.advanceItem label {
+	margin: 0 6px 0 0;
 }
 
 .advanceItem * {
@@ -119,6 +124,7 @@
 
 .toggle {
 	margin-bottom: 5px;
+	font-family: sans-serif;
 }
 
 .imagePreview {

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -4,6 +4,10 @@ import styles from './SearchBox.css';
 import moment from 'moment';
 import featureFlags from 'src/util/featureFlags';
 
+/**
+ * @typedef {import('@types').SearchOptions} SearchOptions
+ */
+
 const SearchBox = ({ options: passedOptions = {}, onSearch, onFileSearch }) => {
 	const defaultOptions = {
 		category: 1023,
@@ -20,9 +24,10 @@ const SearchBox = ({ options: passedOptions = {}, onSearch, onFileSearch }) => {
 		advance: 0,
 		fileSearch: 0,
 		applyOptionsToFileSearch: 0,
+		personally: {have: false, read: false, want: false},
 	};
 	const storedOptions = JSON.parse(localStorage.getItem('searchOptions')) || {};
-	/** @type {import('@types').SearchOptions} */
+	/** @type {SearchOptions} */
 	const options = {
 		...defaultOptions,
 		...storedOptions,
@@ -40,7 +45,7 @@ const SearchBox = ({ options: passedOptions = {}, onSearch, onFileSearch }) => {
 	const [mindate, setMinDate] = useState(options.mindate);
 	const [maxdate, setMaxDate] = useState(options.maxdate);
 	const [showAdvance, setShowAdvance] = useState(+options.advance);
-	const [personal, setPersonal] = useState({});
+	const [personally, setPersonally] = useState(options.personally || defaultOptions.personally);
 	const [showFileSearch, setShowFileSearch] = useState(+options.fileSearch);
 	const [applyOptionsToFileSearch, setApplyOptionsToFileSearch] = useState(false);
 
@@ -142,7 +147,7 @@ const SearchBox = ({ options: passedOptions = {}, onSearch, onFileSearch }) => {
 			mindate,
 			maxdate,
 			advance: +showAdvance,
-			personal,
+			personally,
 		}
 	};
 
@@ -165,8 +170,8 @@ const SearchBox = ({ options: passedOptions = {}, onSearch, onFileSearch }) => {
 		}
 	};
 
-	const onPersonal = (type) => (event) => {
-		setPersonal({...personal, [type]: event.target.checked})
+	const onPersonally = (type) => (event) => {
+		setPersonally({...personally, [type]: event.target.checked})
 	}
 
 	const onSubmit = (event) => {
@@ -246,10 +251,10 @@ const SearchBox = ({ options: passedOptions = {}, onSearch, onFileSearch }) => {
 						<>
 						<span className={styles.advanceItem}>
 							<label>Personally</label>
-							{['Have','Read','Want'].map(p => (
+							{Object.keys(defaultOptions.personally).map((p) => (
 							<label key={p}>
-								<input type="checkbox" checked={!!personal[p]} onChange={onPersonal(p)} />
-								{p}
+								<input type="checkbox" checked={personally[p]} onChange={onPersonally(p)} />
+								{p.charAt(0).toUpperCase() + p.slice(1)}
 							</label>
 							))}
 						</span>

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import categoryList from '../../util/category';
 import styles from './SearchBox.css';
 import moment from 'moment';
+import featureFlags from 'src/util/featureFlags';
 
 const SearchBox = ({ options: passedOptions = {}, onSearch, onFileSearch }) => {
 	const defaultOptions = {
@@ -39,6 +40,7 @@ const SearchBox = ({ options: passedOptions = {}, onSearch, onFileSearch }) => {
 	const [mindate, setMinDate] = useState(options.mindate);
 	const [maxdate, setMaxDate] = useState(options.maxdate);
 	const [showAdvance, setShowAdvance] = useState(+options.advance);
+	const [personal, setPersonal] = useState({});
 	const [showFileSearch, setShowFileSearch] = useState(+options.fileSearch);
 	const [applyOptionsToFileSearch, setApplyOptionsToFileSearch] = useState(false);
 
@@ -140,6 +142,7 @@ const SearchBox = ({ options: passedOptions = {}, onSearch, onFileSearch }) => {
 			mindate,
 			maxdate,
 			advance: +showAdvance,
+			personal,
 		}
 	};
 
@@ -161,6 +164,10 @@ const SearchBox = ({ options: passedOptions = {}, onSearch, onFileSearch }) => {
 			onFileSearch(formData, applyOptionsToFileSearch ? getAllOptions() : undefined);
 		}
 	};
+
+	const onPersonal = (type) => (event) => {
+		setPersonal({...personal, [type]: event.target.checked})
+	}
 
 	const onSubmit = (event) => {
 		event.preventDefault();
@@ -220,18 +227,35 @@ const SearchBox = ({ options: passedOptions = {}, onSearch, onFileSearch }) => {
 			</div>
 			{showAdvance ? (
 				<div className={styles.advance}>
-					<label className={styles.advanceItem}>
-						<input type="checkbox" checked={expunged} onChange={updateExpunged} />
-						Show Expunged
-					</label>
-					<label className={styles.advanceItem}>
-						<input type="checkbox" checked={removed} onChange={updateRemoved} />
-						Show Removed
-					</label>
-					<label className={styles.advanceItem}>
-						<input type="checkbox" checked={replaced} onChange={updateReplaced} />
-						Show Replaced
-					</label>
+					<span className={styles.advanceItem}>
+					<label>Show</label>
+						<label>
+							<input type="checkbox" checked={expunged} onChange={updateExpunged} />
+							Expunged
+						</label>
+						<label>
+							<input type="checkbox" checked={removed} onChange={updateRemoved} />
+							Removed
+						</label>
+						<label>
+							<input type="checkbox" checked={replaced} onChange={updateReplaced} />
+							Replaced
+						</label>
+					</span>
+					{featureFlags.isEnabled('personal') && (
+						<>
+						<span className={styles.advanceItem}>
+							<label>Personally</label>
+							{['Have','Read','Want'].map(p => (
+							<label key={p}>
+								<input type="checkbox" checked={!!personal[p]} onChange={onPersonal(p)} />
+								{p}
+							</label>
+							))}
+						</span>
+						<span className={styles.advanceItem}></span>
+						</>
+					)}
 					<label className={styles.advanceItem}>
 						Show
 						<select value={limit} onChange={updateLimit} className={styles.select}>

--- a/src/util/featureFlags.js
+++ b/src/util/featureFlags.js
@@ -1,0 +1,37 @@
+
+module.exports = {
+	get flags() {
+		// @ts-ignore
+		return JSON.parse(localStorage.getItem('featureFlags')) || {};
+	},
+
+	set flags(values) {
+		localStorage.setItem('featureFlags', JSON.stringify(values));
+	},
+
+	/**
+	 * @param {string} flag
+	 */
+	isEnabled(flag) {
+		return this.flags[flag] === true;
+	},
+
+	/**
+	 * @param {string} flag
+	 * @param {boolean} value
+	 */
+	setFlag(flag, value) {
+		this.flags[flag] = value;
+		localStorage.setItem('featureFlags', JSON.stringify(this.flags));
+	},
+
+	/**
+	 * @param {object} defaults
+	 */
+	initialize(defaults) {
+		// TODO: expose flags through config menu in UI?
+		// if (!localStorage.getItem('featureFlags')) {
+		localStorage.setItem('featureFlags', JSON.stringify(defaults));
+		// }
+	}
+};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,6 +13,9 @@ export type SearchOptions = {
     maxdate: string,
     advance: boolean,
     fileSearch: boolean,
+    personally: {
+        [string]: boolean;
+    },
 }
 
 export type Category =
@@ -41,6 +44,16 @@ export type Torrent = {
     expunged: boolean,
 }
 
+export type Personal = {
+    gid: number,
+    have: boolean,
+    done: boolean,
+    want: boolean,
+    // `flags` bit(8),
+    rating: number,
+    note: string,
+}
+
 export type Gallery = {
     gid: number,
     token: string,
@@ -64,6 +77,12 @@ export type Gallery = {
     bc: number,
     tags: string[],
     torrents: Torrent[],
+    personal: Personal,
+}
+
+export type GalleryOptions = Gallery & {
+    onSearch: (SearchOptions, { append: any }?) => void,
+    onPersonal: (Personal) => void,
 }
 
 export type ImageSearchResult = Gallery & {bc: number}


### PR DESCRIPTION
Hi, I was left thinking about comments in PR #8 ("would be nice if this project could also associated already downloaded dumps of zip/cbz files or folders so you could either read stuff directly off it just like LRR does") still haven't looked into LRR but came up with lightweight solution that's sufficient for my use but does require a little bit of setup from the user.

The screenshot shows the UI elements added, when gallery is marked as "Have" it gets flagged in gallery_personal db table and the UI shows a "Open cbz" link with a custom protocol and the gid "panda://12345", then the OS is configured to handle the custom protocol by running a script, the script knows the directories where user has the cbz files and can match the right file using the gid in the filename then it opens the reader app for that file.

![Screenshot](https://github.com/user-attachments/assets/bb0b7ab4-5fd8-4f9d-96a4-7261136c99e1)

To setup the protocol handler in linux create the script and the handler config:

    cat <<EOF >~/.local/bin/panda.sh
    #!/bin/bash
    [[ ! "$1" =~ ^panda://[0-9]+$ ]] && echo "Syntax: $0 panda://ID" && exit 1
    ID="${1#panda://}"
    # ID followed by one non-numeric character to prevent partial match
    FN=$(find /media/hentai/ -name "${ID}[^0-9]*cbz" -print -quit)
    [ -f "$FN" ] && evince "$FN"
    EOF
    chmod a+x ~/.local/bin/panda.sh

    cat <<EOF >~/.local/share/applications/panda-handler.desktop
    [Desktop Entry]
    Name=panda
    Exec=panda.sh %u
    Type=Application
    MimeType=x-scheme-handler/panda;
    EOF

    # register handler
    xdg-mime default panda-handler.desktop x-scheme-handler/panda
    # this should print the handler filename
    xdg-mime query default x-scheme-handler/panda
    # update browsers etc
    update-desktop-database ~/.local/share/applications/
    # cli open test
    xdg-open panda://123123

That's enough for it to open cbz files from pandabrowser but chrome keeps asking to verify each click which is annoying so by opening chrome://policy/ and "More actions" -> "View logs" shows what path it's loading managed policies from, for me chromium uses /etc/chromium-browser/policies/managed/ and if you create a managed_policies.json file that says `{
 "URLAllowlist": ["panda://*"]
}` in that path it allows the browser to open those links without asking anything.

Once that's all done user could have another script that identifies their cbz files with /imageSearch, renames them with the gid (maybe also adds /comicInfo file in the cbz) and sends a /personal API request to flag the gallery as something they have, then they can search "have" galleries and click to open.

All that's of course entirely different on windows and macos so if this feature is included maybe those should be looked up as well. Also wasn't too sure if everybody necessarily wants this feature so added a feature flag in config.js that hides the UI changes.

Thoughts?